### PR TITLE
fix: add retry handling for dropped streams

### DIFF
--- a/src/electron/types.ts
+++ b/src/electron/types.ts
@@ -197,7 +197,7 @@ export type CreateTaskPayload = {
 // Client -> Server events
 export type ClientEvent =
   | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; allowedTools?: string; model?: string; temperature?: number } }
-  | { type: "session.continue"; payload: { sessionId: string; prompt: string } }
+  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string } }
   | { type: "session.stop"; payload: { sessionId: string } }
   | { type: "session.delete"; payload: { sessionId: string } }
   | { type: "session.pin"; payload: { sessionId: string; isPinned: boolean } }

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -197,7 +197,7 @@ export type ServerEvent =
 // Client -> Server events
 export type ClientEvent =
   | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; model?: string; allowedTools?: string; threadId?: string; temperature?: number } }
-  | { type: "session.continue"; payload: { sessionId: string; prompt: string } }
+  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string } }
   | { type: "session.stop"; payload: { sessionId: string; } }
   | { type: "session.delete"; payload: { sessionId: string; } }
   | { type: "session.pin"; payload: { sessionId: string; isPinned: boolean; } }


### PR DESCRIPTION
adds safe retry logic for streaming responses so transient network failures don’t immediately kill a session. When a stream drops, back off and retry, and notify the UI that a retry is happening.

What changed

- Wrap streaming in a retry loop with exponential backoff.
- Detect retryable network errors and only retry those.
- Emit a retry notice to the UI and avoid duplicating the user prompt.
- Preserve stream metadata and stop retrying once a successful stream completes.