### PR TITLE
chore: add gitattributes for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.png binary


### PR DESCRIPTION
Adds a .gitattributes file to enforce consistent line endings across platforms, reducing CRLF/LF noise in diffs and preventing accidental churn on Windows.