### PR TITLE
fix: make dev script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	"main": "dist-electron/main.js",
 	"scripts": {
 		"dev:clean": "pkill -f \"[v]ite\\\\b\" 2>/dev/null || true; pkill -f \"[e]lectron\\\\s+\\\\.\" 2>/dev/null || true",
-		"dev": "npm run dev:clean && concurrently -k -n react,electron -c cyan,magenta \"npm run dev:react\" \"npm run dev:electron\"",
+		"dev": "node scripts/dev.cjs",
 		"dev:win": "concurrently -k --kill-others-on-fail -n react,electron -c cyan,magenta \"npm run dev:react\" \"npm run dev:electron:delayed\"",
 		"dev:electron:delayed": "node -e \"setTimeout(()=>{},5000)\" && npm run transpile:electron && cross-env NODE_ENV=development electron . --no-sandbox",
 		"dev:react": "vite --host 0.0.0.0 --port 5173 --strictPort",

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+const { spawn, spawnSync } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+
+if (!isWindows) {
+  spawnSync('npm', ['run', 'dev:clean'], { stdio: 'inherit', shell: true });
+}
+
+const electronCommand = isWindows ? 'npm run dev:electron:delayed' : 'npm run dev:electron';
+
+const args = [
+  '-k',
+  '--kill-others-on-fail',
+  '-n',
+  'react,electron',
+  '-c',
+  'cyan,magenta',
+  'npm run dev:react',
+  electronCommand
+];
+
+const proc = spawn('concurrently', args, { stdio: 'inherit', shell: true });
+
+['SIGINT', 'SIGTERM'].forEach((signal) => {
+  process.on(signal, () => {
+    proc.kill(signal);
+  });
+});
+
+proc.on('exit', (code) => {
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
Moves npm run dev to a small Node script so it works consistently on Windows and Unix. On Windows it avoids the Unix‑only dev:clean step and uses the delayed Electron start; on Unix it keeps the existing cleanup behavior.

What changed

- Added scripts/dev.cjs to orchestrate dev processes in a platform‑aware way.
- Updated package.json dev script to call the new Node script.