### PR TITLE
fix: TypeScript build errors in EventCard.tsx

### DIFF
--- a/issue-ts-fix.md
+++ b/issue-ts-fix.md
@@ -1,0 +1,15 @@
+## Bug: TypeScript build errors in EventCard.tsx
+
+`npm run build` fails with 3 TypeScript errors:
+
+```
+src/ui/components/EventCard.tsx:161:22 - error TS2339: Property 'type' does not exist on type 'string | ContentBlockParam'.
+src/ui/components/EventCard.tsx:601:19 - error TS2339: Property 'map' does not exist on type 'string | ContentBlockParam[]'.
+src/ui/components/EventCard.tsx:602:23 - error TS2339: Property 'type' does not exist on type 'string | ContentBlockParam'.
+```
+
+### Root Cause
+`messageContent` and `contents` can be either a string or object, but the code assumes they are always objects with `type` property.
+
+### Fix
+Add type guards to check if values are strings before accessing object properties.

--- a/src/ui/components/EventCard.tsx
+++ b/src/ui/components/EventCard.tsx
@@ -158,7 +158,8 @@ const ToolResult = ({ messageContent }: { messageContent: ToolResultContent }) =
   const isFirstRender = useRef(true);
   let lines: string[] = [];
   
-  if (messageContent.type !== "tool_result") return null;
+  // Type guard: messageContent must be an object with type property
+  if (typeof messageContent === "string" || !messageContent || messageContent.type !== "tool_result") return null;
   
   const toolUseId = messageContent.tool_use_id;
   const status: ToolStatus = messageContent.is_error ? "error" : "success";
@@ -596,13 +597,14 @@ export function MessageCard({
 
   if (sdkMessage.type === "user") {
     const contents = sdkMessage.message.content;
+    // Guard: contents must be an array
+    if (typeof contents === "string" || !Array.isArray(contents)) return null;
     return (
       <>
         {contents.map((content: ToolResultContent, idx: number) => {
-          if (content.type === "tool_result") {
-            return <ToolResult key={idx} messageContent={content} />;
-          }
-          return null;
+          // Guard: content must be an object with type property
+          if (typeof content === "string" || !content || content.type !== "tool_result") return null;
+          return <ToolResult key={idx} messageContent={content} />;
         })}
       </>
     );


### PR DESCRIPTION
Fixes #67

## Changes
- Add type guard for \messageContent\ (check if string before accessing \.type\)
- Add array check for \contents\ before calling \.map()\  
- Add type guard for content items in loop

## Testing
- \
pm run build\ now passes without errors