### PR TITLE
fix: Windows path validation for Cyrillic usernames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "localdesk",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "localdesk",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"hasInstallScript": true,
-			"license": "MIT",
+			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@anthropic-ai/claude-agent-sdk": "^0.2.6",
 				"@radix-ui/react-dialog": "^1.1.15",

--- a/src/electron/libs/tools-executor.ts
+++ b/src/electron/libs/tools-executor.ts
@@ -214,9 +214,9 @@ export class ToolExecutor {
         }
       }
 
-      // Normalize the real path
-      const normalizedRealPath = normalize(realPath);
-      const normalizedCwd = normalize(this.cwd);
+      // Normalize the real path (handles Cyrillic usernames and case differences on Windows)
+      const normalizedRealPath = normalize(realPath).toLowerCase().normalize('NFC');
+      const normalizedCwd = normalize(this.cwd).toLowerCase().normalize('NFC');
 
       // Check if the path is within cwd using string comparison
       // Add separator to prevent partial matches (e.g., /app vs /app-data)

--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -24,5 +24,29 @@ export function ipcWebContentsSend<Key extends keyof EventPayloadMapping>(key: K
 export function validateEventFrame(frame: WebFrameMain) {
     if (isDev() && new URL(frame.url).host === `localhost:${DEV_PORT}`) return;
 
-    if (frame.url !== pathToFileURL(getUIPath()).toString()) throw new Error("Malicious event");
+    // Normalize URLs for comparison:
+    // - Windows paths may have different case for drive letter (C: vs c:)
+    // - Cyrillic usernames may be encoded differently (percent-encoding vs decoded)
+    try {
+        const expectedUrl = new URL(pathToFileURL(getUIPath()).toString());
+        const actualUrl = new URL(frame.url);
+        
+        // Compare decoded pathnames (handles Cyrillic and other non-ASCII chars)
+        const expectedPath = decodeURIComponent(expectedUrl.pathname).toLowerCase();
+        const actualPath = decodeURIComponent(actualUrl.pathname).toLowerCase();
+        
+        // Also check protocol
+        if (actualUrl.protocol !== expectedUrl.protocol || actualPath !== expectedPath) {
+            console.error('[Security] Frame URL mismatch:', { 
+                actual: frame.url, 
+                expected: pathToFileURL(getUIPath()).toString(),
+                actualPath,
+                expectedPath
+            });
+            throw new Error("Malicious event");
+        }
+    } catch (e) {
+        console.error('[Security] URL validation error:', e);
+        throw new Error("Malicious event");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes path validation issues on Windows for users with Cyrillic usernames.

Fixes #71

## Changes

### \src/electron/util.ts\
- \alidateEventFrame()\ now decodes URI and compares paths case-insensitively

### \src/electron/main.ts\
- \list-directory\ handler normalizes paths with \.toLowerCase().normalize('NFC')\

### \src/electron/libs/tools-executor.ts\
- \isPathSafe()\ uses normalized path comparison

### \scripts/dev-electron-delayed.cjs\
- Fixed Windows batch file termination prompt by using async spawn with ignored stdin

## Testing

Tested on Windows 10 with Cyrillic username - all IPC calls and FileBrowser work correctly.