### PR TITLE
feat: paste image attachments with previews

### DIFF
--- a/src/agent/libs/runner.ts
+++ b/src/agent/libs/runner.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import { query, type SDKMessage, type PermissionResult } from "@anthropic-ai/claude-agent-sdk";
-import type { ServerEvent } from "../types.js";
+import type { ServerEvent, ImageAttachment } from "../types.js";
 import type { Session } from "./session-store.js";
 import { claudeCodePath, getEnhancedEnv } from "./util.js";
 import { loadApiSettings } from "./settings-store.js";
@@ -21,6 +21,7 @@ export type RunnerOptions = {
   prompt: string;
   session: Session;
   resumeSessionId?: string;
+  attachments?: ImageAttachment[];
   onEvent: (event: ServerEvent) => void;
   onSessionUpdate?: (updates: Partial<Session>) => void;
 };
@@ -137,7 +138,10 @@ const interceptRequest = (req: any, sessionId: string, protocol: string) => {
 
 
 export async function runClaude(options: RunnerOptions): Promise<RunnerHandle> {
-  const { prompt, session, resumeSessionId, onEvent, onSessionUpdate } = options;
+  const { prompt, session, resumeSessionId, onEvent, onSessionUpdate, attachments } = options;
+  if (attachments && attachments.length > 0) {
+    console.warn("[Claude Runner] Image attachments are not supported and will be ignored.");
+  }
   const abortController = new AbortController();
 
   const sendMessage = (message: SDKMessage) => {

--- a/src/agent/preload.cts
+++ b/src/agent/preload.cts
@@ -29,6 +29,10 @@ electron.contextBridge.exposeInMainWorld("electron", {
         ipcInvoke("get-recent-cwds", limit),
     selectDirectory: () => 
         ipcInvoke("select-directory"),
+    savePastedImage: (payload: { dataUrl: string; cwd: string; fileName?: string }) =>
+        ipcInvoke("save-pasted-image", payload),
+    getImagePreview: (payload: { cwd: string; path: string; maxSize?: number }) =>
+        ipcInvoke("get-image-preview", payload),
     
     // File browser APIs
     invoke: (channel: string, ...args: any[]) => 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -76,9 +76,17 @@ export interface LLMProviderSettings {
   models: LLMModel[];
 }
 
+export type ImageAttachment = {
+  path: string; // Path relative to workspace
+  name?: string;
+  mime?: string;
+  size?: number;
+};
+
 export type UserPromptMessage = {
   type: "user_prompt";
   prompt: string;
+  attachments?: ImageAttachment[];
 };
 
 export type StreamMessage = SDKMessage | UserPromptMessage;
@@ -146,7 +154,7 @@ export type MultiThreadTask = {
 // Server -> Client events
 export type ServerEvent =
   | { type: "stream.message"; payload: { sessionId: string; threadId?: string; message: StreamMessage } }
-  | { type: "stream.user_prompt"; payload: { sessionId: string; threadId?: string; prompt: string } }
+  | { type: "stream.user_prompt"; payload: { sessionId: string; threadId?: string; prompt: string; attachments?: ImageAttachment[] } }
   | { type: "session.status"; payload: { sessionId: string; threadId?: string; status: SessionStatus; title?: string; cwd?: string; error?: string; model?: string; temperature?: number } }
   | { type: "session.list"; payload: { sessions: SessionInfo[] } }
   | { type: "session.history"; payload: { sessionId: string; threadId?: string; status: SessionStatus; messages: StreamMessage[]; inputTokens?: number; outputTokens?: number; todos?: TodoItem[]; model?: string; fileChanges?: FileChange[]; hasMore?: boolean; nextCursor?: number; page?: "initial" | "prepend" } }
@@ -215,8 +223,8 @@ export type CreateTaskPayload = {
 
 // Client -> Server events
 export type ClientEvent =
-  | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; allowedTools?: string; model?: string; temperature?: number } }
-  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string } }
+  | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; allowedTools?: string; model?: string; temperature?: number; attachments?: ImageAttachment[] } }
+  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string; attachments?: ImageAttachment[] } }
   | { type: "session.stop"; payload: { sessionId: string } }
   | { type: "session.delete"; payload: { sessionId: string } }
   | { type: "session.pin"; payload: { sessionId: string; isPinned: boolean } }

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,8 +1,16 @@
 import type { SDKMessage, PermissionResult } from "@anthropic-ai/claude-agent-sdk";
 
+export type ImageAttachment = {
+  path: string; // Path relative to workspace
+  name?: string;
+  mime?: string;
+  size?: number;
+};
+
 export type UserPromptMessage = {
   type: "user_prompt";
   prompt: string;
+  attachments?: ImageAttachment[];
 };
 
 export type StreamMessage = SDKMessage | UserPromptMessage;
@@ -184,7 +192,7 @@ export interface LLMProviderSettings {
 // Server -> Client events
 export type ServerEvent =
   | { type: "stream.message"; payload: { sessionId: string; message: StreamMessage; threadId?: string } }
-  | { type: "stream.user_prompt"; payload: { sessionId: string; prompt: string; threadId?: string } }
+  | { type: "stream.user_prompt"; payload: { sessionId: string; prompt: string; threadId?: string; attachments?: ImageAttachment[] } }
   | { type: "session.status"; payload: { sessionId: string; status: SessionStatus; title?: string; cwd?: string; error?: string; model?: string; temperature?: number; threadId?: string } }
   | { type: "session.list"; payload: { sessions: SessionInfo[] } }
   | { type: "session.history"; payload: { sessionId: string; status: SessionStatus; messages: StreamMessage[]; inputTokens?: number; outputTokens?: number; todos?: TodoItem[]; model?: string; fileChanges?: FileChange[]; hasMore?: boolean; nextCursor?: number; page?: "initial" | "prepend" } }
@@ -215,8 +223,8 @@ export type ServerEvent =
 
 // Client -> Server events
 export type ClientEvent =
-  | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; model?: string; allowedTools?: string; threadId?: string; temperature?: number } }
-  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string } }
+  | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; model?: string; allowedTools?: string; threadId?: string; temperature?: number; attachments?: ImageAttachment[] } }
+  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string; attachments?: ImageAttachment[] } }
   | { type: "session.stop"; payload: { sessionId: string; } }
   | { type: "session.delete"; payload: { sessionId: string; } }
   | { type: "session.pin"; payload: { sessionId: string; isPinned: boolean; } }

--- a/types.d.ts
+++ b/types.d.ts
@@ -42,6 +42,8 @@ type EventPayloadMapping = {
     "write-memory": void;
     "get-build-info": BuildInfo;
     "open-external-url": { success: boolean; error?: string };
+    "save-pasted-image": { path: string; name: string; mime: string; size: number };
+    "get-image-preview": { dataUrl: string; mime: string };
 }
 
 interface Window {
@@ -54,6 +56,8 @@ interface Window {
         generateSessionTitle: (userInput: string | null) => Promise<string>;
         getRecentCwds: (limit?: number) => Promise<string[]>;
         selectDirectory: () => Promise<string | null>;
+        savePastedImage: (payload: { dataUrl: string; cwd: string; fileName?: string }) => Promise<{ path: string; name: string; mime: string; size: number }>;
+        getImagePreview: (payload: { cwd: string; path: string; maxSize?: number }) => Promise<{ dataUrl: string; mime: string }>;
         // File browser APIs
         invoke: (channel: string, ...args: any[]) => Promise<any>;
         send: (channel: string, ...args: any[]) => void;


### PR DESCRIPTION
  Summary

  - Enable pasting images directly into the chat input and Initial Message field, saving them into a workspace-local
    attachments folder.
  - Automatically attach pasted images to the model request (OpenAI runner) with proper image_url content.
  - Add thumbnail previews for pending attachments and in user message history.
  - Verify with image-capable model.