### PR TITLE
fix(memory): use global user-level memory

### DIFF
--- a/src/agent/libs/tools/memory-tool.ts
+++ b/src/agent/libs/tools/memory-tool.ts
@@ -16,13 +16,9 @@ const MEMORY_FILE = 'memory.md';
 
 /**
  * Get memory file path.
- * If cwd is provided, use {cwd}/.localdesk/memory.md (workspace-local)
- * Otherwise, use global ~/.localdesk/memory.md
+ * Always uses global ~/.localdesk/memory.md for user-level memory.
  */
-function getMemoryPath(cwd?: string): string {
-  if (cwd && cwd.trim()) {
-    return join(cwd, LOCALDESK_DIR, MEMORY_FILE);
-  }
+function getMemoryPath(_cwd?: string): string {
   return join(homedir(), LOCALDESK_DIR, MEMORY_FILE);
 }
 
@@ -32,9 +28,7 @@ export const MemoryToolDefinition = {
     name: 'manage_memory',
     description: `Manage long-term memory by storing important information in memory.md file.
     
-Memory storage:
-- **Workspace mode**: If a working directory is set, memory is stored in {cwd}/.localdesk/memory.md (project-specific)
-- **Global mode**: Otherwise, memory is stored in ~/.localdesk/memory.md (persists across all projects)
+Memory is stored globally in ~/.localdesk/memory.md and persists across all projects and sessions.
 
 **BE PROACTIVE**: You should automatically remember important information even if not explicitly asked:
 
@@ -100,8 +94,7 @@ export async function executeMemoryTool(
   context: ToolContext
 ): Promise<{ success: boolean; output?: string; error?: string }> {
   try {
-    const memoryPath = getMemoryPath(context.cwd);
-    const isWorkspaceLocal = context.cwd && context.cwd.trim() ? true : false;
+    const memoryPath = getMemoryPath();
     
     switch (args.operation) {
       case 'create': {
@@ -116,14 +109,13 @@ export async function executeMemoryTool(
         await mkdir(dir, { recursive: true });
         
         const timestamp = new Date().toISOString().split('T')[0];
-        const memoryType = isWorkspaceLocal ? 'workspace' : 'global';
-        const formattedContent = `# Memory (${memoryType})\n\nCreated: ${timestamp}\n\n---\n\n${args.content}\n`;
+        const formattedContent = `# Memory\n\nCreated: ${timestamp}\n\n---\n\n${args.content}\n`;
         
         await writeFile(memoryPath, formattedContent, 'utf-8');
         
         return {
           success: true,
-          output: `Memory file created (${memoryType}): ${memoryPath}\n\nContent:\n${formattedContent}`
+          output: `Memory file created: ${memoryPath}\n\nContent:\n${formattedContent}`
         };
       }
       
@@ -146,8 +138,7 @@ export async function executeMemoryTool(
           if (error.code === 'ENOENT') {
             // File doesn't exist, create it first
             const timestamp = new Date().toISOString().split('T')[0];
-            const memoryType = isWorkspaceLocal ? 'workspace' : 'global';
-            existingContent = `# Memory (${memoryType})\n\nCreated: ${timestamp}\n\n---\n\n`;
+            existingContent = `# Memory\n\nCreated: ${timestamp}\n\n---\n\n`;
           } else {
             throw error;
           }
@@ -158,10 +149,9 @@ export async function executeMemoryTool(
         
         await writeFile(memoryPath, newContent, 'utf-8');
         
-        const memoryType = isWorkspaceLocal ? 'workspace' : 'global';
         return {
           success: true,
-          output: `Added to ${memoryType} memory: ${memoryPath}\n\nNew entry:\n${args.content}`
+          output: `Added to memory: ${memoryPath}\n\nNew entry:\n${args.content}`
         };
       }
       
@@ -222,20 +212,19 @@ export async function executeMemoryTool(
       }
       
       case 'read': {
-        const memoryType = isWorkspaceLocal ? 'workspace' : 'global';
         try {
           await access(memoryPath, constants.F_OK);
           const content = await readFile(memoryPath, 'utf-8');
           
           return {
             success: true,
-            output: `Current ${memoryType} memory (${memoryPath}):\n\n${content}`
+            output: `Current memory (${memoryPath}):\n\n${content}`
           };
         } catch (error: any) {
           if (error.code === 'ENOENT') {
             return {
               success: true,
-              output: `No ${memoryType} memory file exists yet. Use create or append to start building memory.`
+              output: `No memory file exists yet. Use create or append to start building memory.`
             };
           }
           throw error;


### PR DESCRIPTION
## Summary
- Memory is now always stored globally in ~/.localdesk/memory.md
- Removed workspace-local storage option ({cwd}/.localdesk/memory.md)
- Memory persists across all projects and sessions

## Why
User memory should be about the user, not the project. Global storage makes more sense for personal preferences and context.

## Test plan
- [x] Create memory entry - should go to ~/.localdesk/memory.md
- [x] Read memory - should read from global location
- [x] Verify memory persists across different project directories