### PR TITLE
fix: cross-platform sidecar build, token display, and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"preview": "vite preview",
 		"transpile:electron": "tsc --project src/agent/tsconfig.json",
 		"transpile:sidecar": "tsc --project src/sidecar/tsconfig.json && npm run copy:sidecar-prompts",
-		"build:sidecar": "npm run copy:sidecar-prompts && npx esbuild src/sidecar/main.ts --bundle --platform=node --format=cjs --outfile=dist-sidecar/bundled.js --external:sharp --external:electron --external:playwright --external:playwright-core --external:chromium-bidi && pkg dist-sidecar/bundled.js --target node22-macos-arm64 --output src-tauri/bin/valera-sidecar-aarch64-apple-darwin",
+		"build:sidecar": "npm run copy:sidecar-prompts && node scripts/build-sidecar.cjs",
 		"copy:prompts": "node -e \"const fs=require('fs');const path=require('path');fs.mkdirSync('dist-agent/libs/prompts',{recursive:true});fs.readdirSync('src/agent/libs/prompts').filter(f=>f.endsWith('.txt')).forEach(f=>fs.copyFileSync(path.join('src/agent/libs/prompts',f),path.join('dist-agent/libs/prompts',f)))\"",
 		"copy:sidecar-prompts": "node -e \"const fs=require('fs');const path=require('path');fs.mkdirSync('dist-sidecar/agent/libs/prompts',{recursive:true});fs.readdirSync('src/agent/libs/prompts').filter(f=>f.endsWith('.txt')).forEach(f=>fs.copyFileSync(path.join('src/agent/libs/prompts',f),path.join('dist-sidecar/agent/libs/prompts',f)))\"",
 		"type-check": "tsc --noEmit",

--- a/scripts/build-sidecar.cjs
+++ b/scripts/build-sidecar.cjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+// Detect platform and architecture for pkg target and Tauri sidecar naming
+const platform = os.platform();
+const arch = os.arch();
+
+const PKG_TARGETS = {
+  'darwin-arm64':  { pkg: 'node22-macos-arm64',  tauri: 'aarch64-apple-darwin' },
+  'darwin-x64':    { pkg: 'node22-macos-x64',    tauri: 'x86_64-apple-darwin' },
+  'win32-x64':     { pkg: 'node22-win-x64',      tauri: 'x86_64-pc-windows-msvc' },
+  'linux-x64':     { pkg: 'node22-linux-x64',     tauri: 'x86_64-unknown-linux-gnu' },
+  'linux-arm64':   { pkg: 'node22-linux-arm64',   tauri: 'aarch64-unknown-linux-gnu' },
+};
+
+const key = `${platform}-${arch}`;
+const target = PKG_TARGETS[key];
+
+if (!target) {
+  console.error(`Unsupported platform/arch: ${key}`);
+  console.error(`Supported: ${Object.keys(PKG_TARGETS).join(', ')}`);
+  process.exit(1);
+}
+
+const ext = platform === 'win32' ? '.exe' : '';
+const outputPath = path.join('src-tauri', 'bin', `valera-sidecar-${target.tauri}${ext}`);
+
+// Ensure output directory exists
+const binDir = path.join('src-tauri', 'bin');
+if (!fs.existsSync(binDir)) {
+  fs.mkdirSync(binDir, { recursive: true });
+}
+
+console.log(`Platform: ${key}`);
+console.log(`pkg target: ${target.pkg}`);
+console.log(`Output: ${outputPath}`);
+
+// Bundle with esbuild
+console.log('\nBundling sidecar with esbuild...');
+execSync(
+  'npx esbuild src/sidecar/main.ts --bundle --platform=node --format=cjs --outfile=dist-sidecar/bundled.js --external:sharp --external:electron --external:playwright --external:playwright-core --external:chromium-bidi',
+  { stdio: 'inherit' }
+);
+
+// Package with pkg
+console.log('\nPackaging sidecar binary...');
+execSync(
+  `npx @yao-pkg/pkg dist-sidecar/bundled.js --target ${target.pkg} --output ${outputPath}`,
+  { stdio: 'inherit' }
+);
+
+console.log(`\nSidecar built: ${outputPath}`);

--- a/src/agent/libs/llm-providers.ts
+++ b/src/agent/libs/llm-providers.ts
@@ -58,7 +58,7 @@ async function fetchOpenRouterModels(apiKey: string): Promise<PartialModel[]> {
     const models = (data.data || []).map((model: any) => ({
       id: model.id,
       name: `${model.name} (${model.id})`,
-      description: model.description || `${model.pricing.prompt}/1M tokens`,
+      description: model.description || (model.pricing ? `${model.pricing.prompt}/1M tokens` : ''),
       contextLength: model.context_length || undefined,
     }));
 

--- a/src/agent/libs/runner-openai.ts
+++ b/src/agent/libs/runner-openai.ts
@@ -246,7 +246,7 @@ export async function runClaude(options: RunnerOptions): Promise<RunnerHandle> {
         const guiSettings = loadApiSettings();
         
         if (!guiSettings || !guiSettings.baseUrl) {
-          throw new Error('API settings not configured. Please set Base URL (and API Key) in Settings (⚙️).');
+          throw new Error('API settings not configured. If you added an LLM Provider, make sure to select a provider model (with :: in the name) from the model dropdown. Otherwise, set Base URL and API Key in Settings (⚙️).');
         }
         
         if (!guiSettings.apiKey) {
@@ -758,10 +758,10 @@ export async function runClaude(options: RunnerOptions): Promise<RunnerHandle> {
           return;
         }
         
-        // Accumulate token usage
+        // Accumulate token usage (support both OpenAI and llama.cpp field names)
         if (streamMetadata.usage) {
-          totalInputTokens += streamMetadata.usage.prompt_tokens || 0;
-          totalOutputTokens += streamMetadata.usage.completion_tokens || 0;
+          totalInputTokens += streamMetadata.usage.prompt_tokens ?? streamMetadata.usage.input_tokens ?? 0;
+          totalOutputTokens += streamMetadata.usage.completion_tokens ?? streamMetadata.usage.output_tokens ?? 0;
         }
         
         // Log response to file

--- a/src/ui/components/EventCard.tsx
+++ b/src/ui/components/EventCard.tsx
@@ -278,10 +278,10 @@ const ToolUseCard = ({
   showIndicator = false,
   permissionRequest,
   onPermissionResult,
-  sessionId,
+  sessionId: _sessionId, // eslint-disable-line @typescript-eslint/no-unused-vars
   cwd
-}: { 
-  messageContent: MessageContent; 
+}: {
+  messageContent: MessageContent;
   showIndicator?: boolean;
   permissionRequest?: PermissionRequest;
   onPermissionResult?: (toolUseId: string, result: PermissionResult) => void;


### PR DESCRIPTION
## Summary

- **Cross-platform `build:sidecar`** — replaced hardcoded macOS arm64 target with a platform-detecting script (`scripts/build-sidecar.cjs`) that supports macOS, Windows, and Linux
- **Token count display fix** — OpenAI-compatible servers (llama.cpp, vLLM, llamafile) return `input_tokens`/`output_tokens` instead of `prompt_tokens`/`completion_tokens`; now both field names are supported
- **OpenRouter crash fix** — `model.pricing.prompt` throws when `pricing` is undefined (free/new models); added null check
- **Production build fix** — unused `sessionId` variable in `EventCard.tsx` caused `tsc` strict mode to fail on `npm run build`
- **Better error message** — when legacy API settings are missing, the error now hints to select a provider model (with `::`) from the dropdown

## Changed files

| File | Change |
|------|--------|
| `package.json` | `build:sidecar` now calls `scripts/build-sidecar.cjs` |
| `scripts/build-sidecar.cjs` | New cross-platform sidecar build script |
| `src/agent/libs/runner-openai.ts` | Token field fallback + better error message |
| `src/agent/libs/llm-providers.ts` | Null check for OpenRouter pricing |
| `src/ui/components/EventCard.tsx` | Fix unused variable TS error |

## Test plan

- [ ] `npm run build` passes on Windows, macOS, and Linux
- [ ] `npm run build:sidecar` produces correct binary for the current platform
- [ ] Token counts display correctly when using llama.cpp/vLLM server
- [ ] Token counts still display correctly with OpenAI/OpenRouter
- [ ] OpenRouter models without pricing data don't crash on fetch
- [ ] Selecting a non-provider model shows helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)