### PR TITLE
fix: preserve Working Directory and auto-detect Python encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,17 @@
 VALERA_ROOT := $(CURDIR)
 SIDECAR_ENTRY := $(VALERA_ROOT)/dist-sidecar/sidecar/main.js
 MIN_RUST_VERSION := 1.74.0
+IS_WINDOWS := $(findstring Windows,$(OS))
 
 check-tools:
-ifdef OS
+ifneq ($(IS_WINDOWS),)
 	@powershell -ExecutionPolicy ByPass -File ./scripts/ensure_deps.ps1
 else
 	@./scripts/ensure_deps.sh
 endif
 
 ensure-node-deps: check-tools
-ifdef OS
+ifneq ($(IS_WINDOWS),)
 	@powershell -ExecutionPolicy ByPass -File ./scripts/ensure_node_deps.ps1
 else
 	@test -f package-lock.json || { echo "level=error event=missing_file file=package-lock.json msg=\"package-lock.json is required for npm ci\"" >&2; exit 1; }
@@ -25,7 +26,7 @@ else
 endif
 
 ensure-rust:
-ifdef OS
+ifneq ($(IS_WINDOWS),)
 	@powershell -ExecutionPolicy ByPass -File ./scripts/ensure_rust.ps1 -MinRustVersion "$(MIN_RUST_VERSION)"
 else
 	@echo "Checking Rust version..."
@@ -59,7 +60,7 @@ else
 endif
 
 ensure-tauri-cli: ensure-rust
-ifdef OS
+ifneq ($(IS_WINDOWS),)
 	@powershell -ExecutionPolicy ByPass -File ./scripts/ensure_tauri_cli.ps1
 else
 	@if ! command -v cargo-tauri >/dev/null 2>&1; then \
@@ -81,7 +82,7 @@ ensure-tools:
 dev-sidecar: ensure-tools
 	@npm run copy:locales
 	@npm run transpile:sidecar
-ifdef OS
+ifneq ($(IS_WINDOWS),)
 	@powershell -ExecutionPolicy ByPass -File ./scripts/setup_sidecar_mock.ps1
 else
 	@./scripts/setup_sidecar_mock.sh
@@ -95,7 +96,7 @@ dev-tauri: ensure-tools
 
 dev: dev-sidecar
 	@echo "Starting Vite + Tauri (Node-sidecar)..."
-ifdef OS
+ifneq ($(IS_WINDOWS),)
 	@node scripts/dev-tauri.cjs
 else
 	@npm run dev:react & \
@@ -110,7 +111,7 @@ bundle: ensure-tools
 	@echo "Building UI..."
 	@npm run build
 	@echo "Building sidecar binary..."
-ifdef OS
+ifneq ($(IS_WINDOWS),)
 	@powershell -Command "if (-not (Test-Path src-tauri\bin)) { New-Item -ItemType Directory -Path src-tauri\bin | Out-Null }"
 else
 	@mkdir -p src-tauri/bin

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1606,14 +1606,28 @@ fn client_event(app: tauri::AppHandle, state: tauri::State<'_, AppState>, event:
       let payload = event.get("payload").ok_or_else(|| "[session.continue] missing payload".to_string())?;
       let session_id = payload.get("sessionId").and_then(|v| v.as_str())
         .ok_or_else(|| "[session.continue] missing sessionId".to_string())?;
+      let new_cwd = payload.get("cwd").and_then(|v| v.as_str());
       
       eprintln!("[session.continue] Looking up session: {}", session_id);
+      
+      // Update cwd in DB if provided and different from stored
+      if let Some(cwd) = new_cwd {
+        if let Err(e) = state.db.update_session(session_id, &UpdateSessionParams {
+          cwd: Some(cwd.to_string()),
+          ..Default::default()
+        }) {
+          eprintln!("[session.continue] Failed to update cwd in DB: {}", e);
+        } else {
+          eprintln!("[session.continue] Updated cwd to: {}", cwd);
+        }
+      }
       
       // Get session history from DB to provide full context to sidecar
       match state.db.get_session_history(session_id) {
         Ok(Some(history)) => {
+          let final_cwd = new_cwd.or(history.session.cwd.as_deref()).unwrap_or("");
           eprintln!("[session.continue] Found session: title='{}', cwd={:?}, model={:?}, messages={}", 
-            history.session.title, history.session.cwd, history.session.model, history.messages.len());
+            history.session.title, final_cwd, history.session.model, history.messages.len());
           
           // Enrich the event with session data AND message history
           let enriched_event = json!({
@@ -1624,7 +1638,7 @@ fn client_event(app: tauri::AppHandle, state: tauri::State<'_, AppState>, event:
               // Session data for restoration in sidecar
               "sessionData": {
                 "title": history.session.title,
-                "cwd": history.session.cwd,
+                "cwd": final_cwd,
                 "model": history.session.model,
                 "allowedTools": history.session.allowed_tools,
                 "temperature": history.session.temperature

--- a/src/agent/libs/container/quickjs-sandbox.ts
+++ b/src/agent/libs/container/quickjs-sandbox.ts
@@ -151,6 +151,119 @@ export async function executeInQuickJS(
   }
 }
 
+const PYTHON_ENCODING_WRAPPER = `
+import sys; sys.stdout.reconfigure(encoding='utf-8'); sys.stderr.reconfigure(encoding='utf-8')
+import urllib.request
+
+# Monkey-patches urllib and requests to auto-detect encoding (cp1251/utf-8/koi8-r).
+# Safe here because: each execute_python call spawns a fresh subprocess, so patches
+# are isolated to that single execution and never leak to other code.
+
+_orig_urlopen = urllib.request.urlopen
+
+def _detect_and_decode(raw_bytes):
+    if isinstance(raw_bytes, str):
+        return raw_bytes.encode('utf-8')
+    charset = None
+    ct = None
+    for header_name in ('content-type', 'Content-Type'):
+        try:
+            ct = raw_bytes.headers.get(header_name, '')
+        except Exception:
+            pass
+    if ct and 'charset=' in ct:
+        charset = ct.split('charset=')[-1].split(';')[0].strip()
+    if not charset:
+        try:
+            import chardet
+            det = chardet.detect(raw_bytes[:8192] if hasattr(raw_bytes, '__getitem__') else raw_bytes)
+            charset = det.get('encoding') if det and det.get('confidence', 0) > 0.7 else None
+        except Exception:
+            pass  # chardet optional, fall through to encoding guesses
+    for enc in (charset, 'cp1251', 'windows-1251', 'utf-8', 'koi8-r'):
+        if not enc:
+            continue
+        try:
+            return raw_bytes.decode(enc).encode('utf-8')
+        except Exception:
+            pass
+    return raw_bytes.decode('utf-8', errors='replace').encode('utf-8')
+
+class _AutoDecodeResponse:
+    def __init__(self, original_response):
+        self._orig = original_response
+        try:
+            self.content = _detect_and_decode(original_response.read())
+        except Exception as e:
+            sys.stderr.write('[encoding-wrapper] Failed to decode response: ' + str(e) + '\\n')
+            self.content = original_response.read()
+    def read(self, n=-1):
+        if n < 0:
+            return self.content
+        return self.content[:n]
+    def __getattr__(self, name):
+        return getattr(self._orig, name)
+
+def _auto_urlopen(url, *args, **kwargs):
+    response = _orig_urlopen(url, *args, **kwargs)
+    try:
+        return _AutoDecodeResponse(response)
+    except Exception as e:
+        sys.stderr.write('[encoding-wrapper] Failed to wrap urlopen response: ' + str(e) + '\\n')
+        return response
+
+urllib.request.urlopen = _auto_urlopen
+
+try:
+    import requests
+
+    _orig_requests_get = requests.get
+    _orig_requests_session_request = None
+
+    class _AutoDecodeRequestsResponse:
+        def __init__(self, original_response):
+            self._orig = original_response
+            try:
+                raw = original_response.content
+                self._decoded = _detect_and_decode(raw)
+            except Exception as e:
+                sys.stderr.write('[encoding-wrapper] Failed to decode requests response: ' + str(e) + '\\n')
+                self._decoded = original_response.content
+        @property
+        def content(self):
+            return self._decoded
+        @property
+        def text(self):
+            return self._decoded.decode('utf-8', errors='replace')
+        def __getattr__(self, name):
+            return getattr(self._orig, name)
+
+    def _auto_requests_get(url, **kwargs):
+        resp = _orig_requests_get(url, **kwargs)
+        try:
+            return _AutoDecodeRequestsResponse(resp)
+        except Exception as e:
+            sys.stderr.write('[encoding-wrapper] Failed to wrap requests.get: ' + str(e) + '\\n')
+            return resp
+
+    def _auto_requests_session_init(self, *args, **kwargs):
+        _orig_requests_session_init(self, *args, **kwargs)
+        _orig_session_request = self.request
+        def _auto_session_request(method, url, **kw):
+            resp = _orig_session_request(method, url, **kw)
+            try:
+                return _AutoDecodeRequestsResponse(resp)
+            except Exception:
+                return resp
+        self.request = _auto_session_request
+
+    _orig_requests_session_init = requests.Session.__init__
+    requests.Session.__init__ = _auto_requests_session_init
+    requests.get = _auto_requests_get
+except Exception as e:
+    sys.stderr.write('[encoding-wrapper] Failed to patch requests library: ' + str(e) + '\\n')
+`;
+
 /**
  * Execute Python code (requires Python 3 installed)
  */
@@ -168,7 +281,9 @@ export async function executePython(
     // Find Python
     const pythonCmd = process.platform === 'win32' ? 'python' : 'python3';
     
-    const proc = spawn(pythonCmd, ['-c', code], {
+    const wrappedCode = PYTHON_ENCODING_WRAPPER + '\n\n' + code;
+    
+    const proc = spawn(pythonCmd, ['-c', wrappedCode], {
       cwd,
       timeout,
       stdio: ['pipe', 'pipe', 'pipe']

--- a/src/agent/libs/runner-openai.ts
+++ b/src/agent/libs/runner-openai.ts
@@ -1505,12 +1505,14 @@ export async function runClaude(options: RunnerOptions): Promise<RunnerHandle> {
                 if (isGitRepo(session.cwd)) {
                   relativePath = getRelativePath(filePath, session.cwd);
                 } else {
-                  // For non-git repos, use path relative to cwd
-                  try {
-                    relativePath = relative(session.cwd, filePath) || filePath;
-                  } catch {
-                    relativePath = filePath;
-                  }
+                // For non-git repos, use path relative to cwd
+                try {
+                  // filePath may be relative; resolve it against session.cwd first
+                  const absoluteFilePath = resolve(session.cwd, filePath);
+                  relativePath = relative(session.cwd, absoluteFilePath) || filePath;
+                } catch {
+                  relativePath = filePath;
+                }
                 }
 
                 // Use diffSnapshot from tool result if available (more accurate)

--- a/src/agent/libs/tools/execute-python-tool.ts
+++ b/src/agent/libs/tools/execute-python-tool.ts
@@ -49,6 +49,11 @@ print(f"Found {len(files)} files")
 
 **IF IMPORT FAILS**: Package not installed. Use bash tool to run: pip install <package>
 
+**ENCODING NOTE**:
+Web content (especially Russian sites) may use Windows-1251 or other non-UTF-8 encodings.
+The sandbox auto-detects encoding — urlopen().read() returns UTF-8 bytes.
+Use: html = urlopen(url).read().decode("utf-8")  ✓ works for all sites
+
 **LIMITATIONS**: 
 - Requires Python 3 on user's system
 - pip packages must be pre-installed (or use bash to install)

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -320,7 +320,7 @@ export type CreateTaskPayload = {
 // Client -> Server events
 export type ClientEvent =
   | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; allowedTools?: string; model?: string; temperature?: number } }
-  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string } }
+  | { type: "session.continue"; payload: { sessionId: string; prompt: string; cwd?: string; retry?: boolean; retryReason?: string } }
   | { type: "session.stop"; payload: { sessionId: string } }
   | { type: "session.delete"; payload: { sessionId: string } }
   | { type: "session.pin"; payload: { sessionId: string; isPinned: boolean } }

--- a/src/sidecar/main.ts
+++ b/src/sidecar/main.ts
@@ -668,7 +668,7 @@ function handleSessionStart(event: Extract<ClientEvent, { type: "session.start" 
 }
 
 function handleSessionContinue(event: Extract<ClientEvent, { type: "session.continue" }>) {
-  const { sessionId, prompt, sessionData, messages: historyMessages, todos: historyTodos } = event.payload as any;
+  const { sessionId, prompt, cwd: newCwd, sessionData, messages: historyMessages, todos: historyTodos } = event.payload as any;
   let session = sessions.getSession(sessionId);
   
   // If session not in memory, try to restore from sessionData (provided by Rust)
@@ -694,6 +694,14 @@ function handleSessionContinue(event: Extract<ClientEvent, { type: "session.cont
     // Restore todos from DB
     if (historyTodos && Array.isArray(historyTodos)) {
       (sessions as any).todos.set(sessionId, historyTodos);
+    }
+  }
+  
+  // Update cwd if a new one was provided (from UI, overrides stored cwd)
+  if (newCwd) {
+    sessions.updateSession(sessionId, { cwd: newCwd });
+    if (session) {
+      session.cwd = newCwd;
     }
   }
   

--- a/src/ui/components/PromptInput.tsx
+++ b/src/ui/components/PromptInput.tsx
@@ -94,7 +94,7 @@ export function usePromptActions(sendEvent: (event: ClientEvent) => void, forced
         setGlobalError(t("promptInput.sessionStillRunning"));
         return;
       }
-      sendEvent({ type: "session.continue", payload: { sessionId: activeSessionId, prompt: trimmedPrompt } });
+      sendEvent({ type: "session.continue", payload: { sessionId: activeSessionId, prompt: trimmedPrompt, cwd: cwd.trim() || undefined } });
     }
     setPrompt("");
   }, [activeSession, activeSessionId, cwd, prompt, sendEvent, setGlobalError, setPendingStart, setPrompt, selectedModel, selectedTemperature, sendTemperature]);

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -326,7 +326,7 @@ export type ServerEvent =
 // Client -> Server events
 export type ClientEvent =
   | { type: "session.start"; payload: { title: string; prompt: string; cwd?: string; model?: string; allowedTools?: string; threadId?: string; temperature?: number } }
-  | { type: "session.continue"; payload: { sessionId: string; prompt: string; retry?: boolean; retryReason?: string } }
+  | { type: "session.continue"; payload: { sessionId: string; prompt: string; cwd?: string; retry?: boolean; retryReason?: string } }
   | { type: "session.stop"; payload: { sessionId: string; } }
   | { type: "session.delete"; payload: { sessionId: string; } }
   | { type: "session.pin"; payload: { sessionId: string; isPinned: boolean; } }


### PR DESCRIPTION
## Summary

- Add `PYTHON_ENCODING_WRAPPER` to `execute_python`: auto-detect Windows-1251/UTF-8/KOI8-R encoding for `urllib` and `requests`, prevent `UnicodeDecodeError` on Russian sites; switch Python stdout/stderr to UTF-8
- Propagate `cwd` through `session.continue` event (UI → Rust → DB → Sidecar), fix `relativePath` calculation with `resolve()` — files are now created in Working Directory and displayed correctly in Changed Files UI
- Add `ENCODING NOTE` to `execute_python` tool description

## Changes

| File | Change |
|------|--------|
| src/agent/libs/container/quickjs-sandbox.ts | Add encoding wrapper for urllib/requests |
| src/agent/libs/tools/execute-python-tool.ts | Add ENCODING NOTE to tool description |
| src/agent/libs/runner-openai.ts | Resolve relative filePath before relative() |
| src/sidecar/main.ts | Accept and apply cwd from session.continue payload |
| src/ui/components/PromptInput.tsx | Pass cwd in session.continue |
| src-tauri/src/main.rs | Accept cwd from session.continue, save to DB |
| src/ui/types.ts, src/agent/types.ts | Add cwd to session.continue type |
| Makefile | Fix OS detection: ifdef OS → ifneq($(IS_WINDOWS),) |


## Conventions

PR follows project conventions from `docs/development.md`:
- **Commit format**: `fix: description`
- **Branch naming**: `fix/*` for bug fixes
- **File naming**: `kebab-case.ts`, `PascalCase.tsx` for components

## Model

Changes were made using `minimax-m2.5-free` (opencode/minimax-m2.5-free) AI assistant.